### PR TITLE
chore: Post-release version bump to 0.1.0-rc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repos"
-version = "0.0.14"
+version = "0.1.0-rc"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
This PR merges the changes from release `` back into main and prepares for the next development cycle by bumping the version to `0.1.0-rc`.